### PR TITLE
closing the req loop finally

### DIFF
--- a/board/templates/home.html
+++ b/board/templates/home.html
@@ -181,8 +181,9 @@
                         dataType : "json",
                         success: function( data ){
                             console.log("training requested ...",data)
-                            setTimeout(function(){ port = getTBPort()
-                            workspaces_div.append('<div class="model-div"><iframe src="http://localhost:'+port+'" height="800px" width="100%"></iframe></div>') }, 3000);
+                            setTimeout(function(){ 
+                                port = data['msg']
+                            workspaces_div.append('<div class="model-div"><iframe src="http://localhost:'+port+'" height="800px" width="100%"></iframe></div>') }, 10000);
                         }
                     });
                 });

--- a/board/views.py
+++ b/board/views.py
@@ -135,7 +135,7 @@ def create(request):
 
     # TODO: add try catch here (in case the tensorboard couldnt be started)
     
-    cmd = "tensorboard --logdir "+LOG_DIR+" --port "+tensorboard_port 
+    cmd = "tensorboard --logdir "+LOG_DIR+" --host localhost --port "+tensorboard_port 
     tb_p = Process(target=os.system, args=(cmd,))
     tb_p.start()
     tb_p.join(2)


### PR DESCRIPTION
# Description 
- get port directly from the training function (no need for 1 extra API call)
- use `localhost` while starting tensorboard
Please include a summary of the change and which issue is fixed. Please also include related PRs. List any dependencies that are required for this change.

# Test/Benchmark Outputs

# Checklist:
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] Related Benchmarks have been performed, if applicable.
- [x] I have a plan to revert my changes.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if applicable.
